### PR TITLE
处理获取token错误并补全错误信息

### DIFF
--- a/access_token.go
+++ b/access_token.go
@@ -1,6 +1,8 @@
 package wechat3rd
 
 import (
+	"errors"
+	"fmt"
 	"github.com/l306287405/wechat3rd/core"
 	"time"
 )
@@ -24,9 +26,9 @@ type DefaultAccessTokenServer struct {
 
 // token不使用不获取
 func (d *DefaultAccessTokenServer) Token() (token string, err error) {
-	var(
+	var (
 		ticket string
-		resp *AccessTokenResp
+		resp   *AccessTokenResp
 	)
 
 	if d.ExpiresIn <= time.Now().Unix()-30 {
@@ -40,6 +42,10 @@ func (d *DefaultAccessTokenServer) Token() (token string, err error) {
 			ComponentVerifyTicket: ticket,
 		})
 		if err != nil {
+			return
+		}
+		if resp != nil && resp.ErrCode != 0 {
+			err = errors.New(fmt.Sprintf("get component_access_token errcode: %d,errmsg: %s", resp.ErrCode, resp.ErrMsg))
 			return
 		}
 		d.ExpiresIn = time.Now().Unix() + resp.ExpiresIn


### PR DESCRIPTION
```
* 改动的主要原因是因为我在使用sdk过程中，发现调用Service第三方小程序相关接口一直报错。
* 最终定位问题是，我白名单ip没配然后没获取component_access_token，但是sdk没有返回报错信息，把空的component_access_token拿去http请求接口就会报错。
* 所以我提PR补全了返回错误信息，方便排查和定位问题防止其他人踩坑。
```