### PR TITLE
access_token和设置服务器域名的改动

### DIFF
--- a/access_token.go
+++ b/access_token.go
@@ -14,6 +14,7 @@ const (
 
 type AccessTokenServer interface {
 	Token() (token string, err error)
+	GetToken() (token string, expiresIn int64, err error)
 	RestoreToken(token string, expiresIn int64) (err error)
 }
 
@@ -57,6 +58,17 @@ func (d *DefaultAccessTokenServer) Token() (token string, err error) {
 func (d *DefaultAccessTokenServer) RestoreToken(token string, expiresIn int64) (err error) {
 	d.ExpiresIn = expiresIn
 	d.ComponentAccessToken = token
+	return
+}
+
+// 获取当前对象中的token
+func (d *DefaultAccessTokenServer) GetToken() (token string, expiresIn int64, err error) {
+	if d.ExpiresIn <= time.Now().Unix() {
+		err = errors.New("token expires")
+	} else {
+		token = d.ComponentAccessToken
+		expiresIn = d.ExpiresIn
+	}
 	return
 }
 

--- a/account.go
+++ b/account.go
@@ -53,14 +53,25 @@ type ModifyDomainReq struct {
 	Wsrequestdomain []string `json:"wsrequestdomain"`
 	Uploaddomain    []string `json:"uploaddomain"`
 	Downloaddomain  []string `json:"downloaddomain"`
+	Udpdomain       []string `json:"udpdomain"`
+	Tcpdomain       []string `json:"tcpdomain"`
 }
 
 type ModifyDomainResp struct {
 	core.Error
-	Requestdomain   []string `json:"requestdomain"`
-	Wsrequestdomain []string `json:"wsrequestdomain"`
-	Uploaddomain    []string `json:"uploaddomain"`
-	Downloaddomain  []string `json:"downloaddomain"`
+	Requestdomain          []string `json:"requestdomain"`
+	Wsrequestdomain        []string `json:"wsrequestdomain"`
+	Uploaddomain           []string `json:"uploaddomain"`
+	Downloaddomain         []string `json:"downloaddomain"`
+	Udpdomain              []string `json:"udpdomain"`
+	Tcpdomain              []string `json:"tcpdomain"`
+	InvalidRequestdomain   []string `json:"invalid_requestdomain"`
+	InvalidWsrequestdomain []string `json:"invalid_wsrequestdomain"`
+	InvalidUploaddomain    []string `json:"invalid_uploaddomain"`
+	InvalidDownloaddomain  []string `json:"invalid_downloaddomain"`
+	InvalidUdpdomain       []string `json:"invalid_udpdomain"`
+	InvalidTcpdomain       []string `json:"invalid_tcpdomain"`
+	NoIcpDomain            []string `json:"no_icp_domain"`
 }
 
 //设置服务器域名


### PR DESCRIPTION
1. access token中增加GetToken方法，以让其它缓存系统能得到过期时间，而做自动刷新的处理;
2. 设置服务器域名的请求和响应参数扩展为跟微信官方保持一致，以让业务系统能得到更多的设置和显示具体失败的设置。
