### PR TITLE
实现复用公众号主体快速注册小程序接口及修改部分逻辑

### DIFF
--- a/access_token.go
+++ b/access_token.go
@@ -61,14 +61,12 @@ func (d *DefaultAccessTokenServer) RestoreToken(token string, expiresIn int64) (
 	return
 }
 
-// 获取当前对象中的token
+// 获取令牌（component_access_token),带有过期时间的时间戳。
 func (d *DefaultAccessTokenServer) GetToken() (token string, expiresIn int64, err error) {
-	if d.ExpiresIn <= time.Now().Unix() {
-		err = errors.New("token expires")
-	} else {
-		token = d.ComponentAccessToken
+	if token, err = d.Token(); err == nil {
 		expiresIn = d.ExpiresIn
 	}
+
 	return
 }
 

--- a/code.go
+++ b/code.go
@@ -2,11 +2,12 @@ package wechat3rd
 
 import (
 	"errors"
-	"github.com/l306287405/wechat3rd/core"
 	"net/http"
 	"net/url"
 	"os"
 	"strings"
+
+	"github.com/l306287405/wechat3rd/core"
 )
 
 type GetTemplateDraftListResp struct {
@@ -323,7 +324,7 @@ func (s *Server) RevertCodeRelease(accessToken string) (resp *core.Error) {
 
 type GetRevertCodeReleaseResp struct {
 	core.Error
-	TemplateList []*RevertTemplate `json:"template_list"` //模板信息列表
+	TemplateList []*RevertTemplate `json:"version_list"` //版本信息列表
 }
 
 type RevertTemplate struct {
@@ -454,7 +455,7 @@ func (s *Server) ChangeVisitStatus(accessToken string, action string) (resp *cor
 
 type GetWeappSupportVersionResp struct {
 	core.Error
-	NowVersion string `json:"now_version"` //当前版本
+	NowVersion string    `json:"now_version"` //当前版本
 	UvInfo     *struct { //版本的用户占比列表
 		Items []*struct {
 			Percentage float64 `json:"percentage"` //百分比

--- a/code.go
+++ b/code.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strconv"
 	"strings"
 
 	"github.com/l306287405/wechat3rd/core"
@@ -313,12 +314,17 @@ func (s *Server) Release(accessToken string) (resp *core.Error) {
 
 //版本回退
 //https://developers.weixin.qq.com/doc/oplatform/Third-party_Platforms/2.0/api/code/revertcoderelease.html
-func (s *Server) RevertCodeRelease(accessToken string) (resp *core.Error) {
+func (s *Server) RevertCodeRelease(accessToken string, appVersion int) (resp *core.Error) {
 	var (
-		u = WECHAT_API_URL + "/wxa/revertcoderelease?"
+		u      = WECHAT_API_URL + "/wxa/revertcoderelease?"
+		params = core.AuthTokenUrlValues(accessToken)
 	)
+	//版本为零则回退到上一个版本
+	if appVersion != 0 {
+		params.Set("app_version", strconv.Itoa(appVersion))
+	}
 	resp = &core.Error{}
-	resp.Err(core.GetRequest(u, core.AuthTokenUrlValues(accessToken), resp))
+	resp.Err(core.GetRequest(u, params, resp))
 	return
 }
 

--- a/fastregisterweapp.go
+++ b/fastregisterweapp.go
@@ -1,11 +1,16 @@
 package wechat3rd
 
 import (
-	"github.com/l306287405/wechat3rd/core"
 	"net/url"
+
+	"github.com/l306287405/wechat3rd/core"
 )
 
-const WeAPPRegisterUrl = "https://api.weixin.qq.com/cgi-bin/component/fastregisterweapp?"
+const (
+	WeAPPRegisterUrl = CGIUrl + "/component/fastregisterweapp?"
+	FastregisterUrl  = CGIUrl + "/account/fastregister"
+	MPAuthUrl        = WECHAT_MP_URL + "/cgi-bin/fastregisterauth"
+)
 
 type FastRegisterWeappReq struct {
 	Name               string `json:"name"`                 //企业名
@@ -60,5 +65,41 @@ func (s *Server) SearchWeapp(req *SearchWeappReq) (resp *core.Error) {
 	p.Set("action", "search")
 	p.Set("component_access_token", token)
 	resp.Err(core.PostJson(WeAPPRegisterUrl+p.Encode(), req, resp))
+	return
+}
+
+//获取微信公众平台授权页面链接
+//https://developers.weixin.qq.com/doc/oplatform/Third-party_Platforms/2.0/api/Register_Mini_Programs/fast_registration_of_mini_program.html
+func (srv *Server) GetMPAuthUrl(mpAppID, redirectUri string, copyWxVerify bool) (u string) {
+	p := url.Values{}
+	p.Set("component_appid", srv.cfg.AppID)
+	p.Set("appid", mpAppID)
+	cwv := "1"
+	if !copyWxVerify {
+		cwv = "0"
+	}
+	p.Set("copy_wx_verify", cwv)
+	p.Set("redirect_uri", redirectUri)
+	u = MPAuthUrl + "?" + p.Encode()
+	return
+}
+
+//复用公众号主体快速注册小程序
+type FastRegisterReq struct {
+	Ticket string `json:"ticket"` //公众号扫码授权的凭证(公众平台扫码页面回跳到第三方平台时携带)
+}
+type FastRegisterResp struct {
+	core.Error
+	Appid             string `json:"appid"`              //新创建小程序的 appid
+	AuthorizationCode string `json:"authorization_code"` //新创建小程序的授权码
+	IsWxVerifySucc    bool   `json:"is_wx_verify_succ"`  //复用公众号微信认证小程序是否成功
+	IsLinkSucc        bool   `json:"is_link_succ"`       //小程序是否和公众号关联成功
+}
+
+//https://developers.weixin.qq.com/doc/oplatform/Third-party_Platforms/2.0/api/Register_Mini_Programs/fast_registration_of_mini_program.html
+func (s *Server) FastRegister(accessToken string, req *FastRegisterReq) (resp *FastRegisterResp) {
+	resp = &FastRegisterResp{}
+	tUrl := s.AuthToken2url(FastregisterUrl, accessToken)
+	resp.Err(core.PostJson(tUrl, req, resp))
 	return
 }

--- a/pre_auth_code.go
+++ b/pre_auth_code.go
@@ -3,6 +3,8 @@ package wechat3rd
 import (
 	"errors"
 	"fmt"
+	"net/url"
+
 	"github.com/l306287405/wechat3rd/core"
 )
 
@@ -55,10 +57,12 @@ func (srv *Server) AuthUrl(isWebAuth bool, redirectUri string, authType AuthType
 		err = errors.New(resp.ErrMsg)
 		return
 	}
+	tPreAuthCode := url.QueryEscape(resp.PreAuthCode)
+	redirectUri = url.QueryEscape(redirectUri)
 	if isWebAuth {
-		u = fmt.Sprintf(WEB_AUTH_URL, srv.cfg.AppID, resp.PreAuthCode, redirectUri, authType)
+		u = fmt.Sprintf(WEB_AUTH_URL, srv.cfg.AppID, tPreAuthCode, redirectUri, authType)
 	} else {
-		u = fmt.Sprintf(MOBILE_AUTH_URL, srv.cfg.AppID, resp.PreAuthCode, redirectUri, authType)
+		u = fmt.Sprintf(MOBILE_AUTH_URL, srv.cfg.AppID, tPreAuthCode, redirectUri, authType)
 		if bizAppid != nil && *bizAppid != "" {
 			u = u + "&biz_appid=" + *bizAppid
 		}


### PR DESCRIPTION
- [修改获取令牌（component_access_token),带有过期时间的时间戳, 以让其它缓存能存储](https://github.com/l306287405/wechat3rd/commit/5baa7e0a4c448502969e8a3c173c611b36fef603)
- [修改获取可回退的小程序版本中返回参数版本信息列表的误写](https://github.com/l306287405/wechat3rd/commit/bfb7ca5649c9c868c902bcca0f19f80e102cadbe)
- [版本回退增加指定的版本号，版本为零则回退到上一个版本](https://github.com/l306287405/wechat3rd/commit/3fa66340daa实现复用公众号主体快速注册小程序接口98399cb520e7830567256adcf9e69)
- [实现复用公众号主体快速注册小程序接口](https://github.com/l306287405/wechat3rd/commit/ec8e25bf4e4a45fc6131bbdb963c643ab5a2aac9)
- [为AuthUrl的PreAuthCode和redirectUri加上urlencode](https://github.com/l306287405/wechat3rd/commit/607edda99f5c01696038653bbde5a0b2bcb9e0ab)