### PR TITLE
提交代码审核增加必填字段PrivacyApiNotUse

### DIFF
--- a/code.go
+++ b/code.go
@@ -94,12 +94,13 @@ func (s *Server) GetQrcode(authorizerAccessToken string, path, saveDir, fileName
 }
 
 type SubmitAuditReq struct {
-	ItemList      []*SubmitAuditItem      `json:"item_list,omitempty"`
-	PreviewInfo   *SubmitAuditPreviewInfo `json:"preview_info,omitempty"`
-	VersionDesc   *string                 `json:"version_desc,omitempty"`
-	FeedbackInfo  *string                 `json:"feedback_info,omitempty"`
-	FeedbackStuff *string                 `json:"feedback_stuff,omitempty"`
-	UgcDeclare    *SubmitAuditUgcDeclare  `json:"ugc_declare,omitempty"`
+	ItemList         []*SubmitAuditItem      `json:"item_list,omitempty"`
+	PreviewInfo      *SubmitAuditPreviewInfo `json:"preview_info,omitempty"`
+	VersionDesc      *string                 `json:"version_desc,omitempty"`
+	FeedbackInfo     *string                 `json:"feedback_info,omitempty"`
+	FeedbackStuff    *string                 `json:"feedback_stuff,omitempty"`
+	UgcDeclare       *SubmitAuditUgcDeclare  `json:"ugc_declare,omitempty"`
+	PrivacyApiNotUse *bool                   `json:"privacy_api_not_use,omitempty"`
 }
 
 type SubmitAuditUgcDeclare struct {


### PR DESCRIPTION
https://developers.weixin.qq.com/doc/oplatform/openApi/OpenApiDoc/miniprogram-management/code-management/submitAudit.html
我建议很多接口的文档不应该指向https://developers.weixin.qq.com/doc/oplatform/Third-party_Platforms/2.0/api这个位置，官方文档现在以新的那个为准